### PR TITLE
Add transformation pruning test case and remove dfs, Fixes #10

### DIFF
--- a/PyRDF/CallableGenerator.py
+++ b/PyRDF/CallableGenerator.py
@@ -64,7 +64,7 @@ class CallableGenerator(object):
 
         """
 
-        self.root_node._graph_prune()
+        self.root_node.graph_prune()
 
         self.actions = 0
         self.tfs = 0

--- a/PyRDF/Node.py
+++ b/PyRDF/Node.py
@@ -36,37 +36,19 @@ class Node(object):
 
         return newNode
     
-    def _dfs(self, node, prev_object= None):
-        """
-        Do a depth-first traversal of the graph from the root
-
-        """
-        if not node.operation:
-            prev_object = node._tdf
-            self._graph_prune()
-
-        else:
-            ## Execution of the node
-            op = getattr(prev_object, node.operation.name)
-            node.value = op(*node.operation.args, **node.operation.kwargs)
-        
-        for n in node.next_nodes:
-            self._dfs(n, node.value)
-
-    
-    def _graph_prune(self):
+    def graph_prune(self):
 
         children = []
 
         for n in self.next_nodes:
-            if n._graph_prune():
+            if n.graph_prune():
                 children.append(n)
         self.next_nodes = children
 
         if not self.next_nodes and len(gc.get_referrers(self)) <= 3:
             
             ### The 3 referrers to the current node would be :
-            ### - The current function (_graph_prune())
+            ### - The current function (graph_prune())
             ### - An internal reference (which every Python object has)
             ### - The current node's parent node
             ###

--- a/tests/test_callable_generator.py
+++ b/tests/test_callable_generator.py
@@ -22,7 +22,7 @@ class CallableGeneratorTest(unittest.TestCase):
         t = CallableGeneratorTest.Temp()
 
         node = Node(None, None)
-        node.value = t
+
         n1 = node.Define()
         n2 = node.Filter().Filter()
         n4 = n2.Count()
@@ -42,7 +42,6 @@ class CallableGeneratorTest(unittest.TestCase):
         t = CallableGeneratorTest.Temp()
 
         node = Node(None, None)
-        node.value = t
         n1 = node.Define()
         n2 = node.Filter().Filter()
         n4 = n2.Count()

--- a/tests/test_node.py
+++ b/tests/test_node.py
@@ -46,39 +46,32 @@ class DfsTest(unittest.TestCase):
             self.ord_list.append(3)
             return self
 
-    def test_dfs_order_small(self):
-        t = DfsTest.Temp()
+    @classmethod
+    def traverse(cls, node, prev_object= None):
+        """
+        Do a depth-first traversal of the graph from the root
+
+        """
+        if not node.operation:
+            prev_object = DfsTest.Temp()
+            node.value = prev_object
+            node.graph_prune()
+
+        else:
+            ## Execution of the node
+            op = getattr(prev_object, node.operation.name)
+            node.value = op(*node.operation.args, **node.operation.kwargs)
+
+        for n in node.next_nodes:
+            DfsTest.traverse(n, node.value)
+
+        return prev_object.ord_list
+
+
+    def test_dfs_graph_with_pruning_actions(self):
 
         node = Node(None, None)
-        node.value = t
 
-        node._dfs(node = node._get_head())
-
-        self.assertEqual(t.ord_list, [])
-
-    def test_dfs_order_big(self):
-        t = DfsTest.Temp()
-
-        node = Node(None, None)
-        node.value = t
-        n1 = node.Define()
-        n2 = node.Filter()
-        n3 = n2.Filter()
-        n4 = n3.Count()
-        n5 = n1.Count()
-        n6 = node.Filter()
-
-        node._dfs(node = node._get_head())
-
-        reqd_order = [1, 3, 2, 2, 3, 2]
-
-        self.assertEqual(t.ord_list, reqd_order)
-
-    def test_dfs_graph_pruning(self):
-        t = DfsTest.Temp()
-
-        node = Node(None, None)
-        node.value = t
         n1 = node.Define()
         n2 = node.Filter()
         n3 = n2.Filter()
@@ -88,8 +81,44 @@ class DfsTest(unittest.TestCase):
 
         n5 = n1.Filter()
 
-        node._dfs(node = node._get_head())
+        obtained_order = DfsTest.traverse(node = node._get_head())
 
         reqd_order = [1, 2, 2, 2, 3, 2]
 
-        self.assertEqual(t.ord_list, reqd_order)
+        self.assertEqual(obtained_order, reqd_order)
+
+    def test_dfs_graph_with_pruning_transformations(self):
+
+        node = Node(None, None)
+
+        n1 = node.Define()
+        n2 = node.Filter()
+        n3 = n2.Filter()
+        n4 = n3.Count()
+        n5 = n1.Filter()
+        n6 = node.Filter()
+
+        n5 = n1.Count()
+
+        obtained_order = DfsTest.traverse(node = node._get_head())
+
+        reqd_order = [1, 3, 2, 2, 3, 2]
+
+        self.assertEqual(obtained_order, reqd_order)
+
+    def test_dfs_graph_without_pruning(self):
+
+        node = Node(None, None)
+
+        n1 = node.Define()
+        n2 = node.Filter()
+        n3 = n2.Filter()
+        n4 = n3.Count()
+        n5 = n1.Count()
+        n6 = node.Filter()
+
+        obtained_order = DfsTest.traverse(node = node._get_head())
+
+        reqd_order = [1, 3, 2, 2, 3, 2]
+
+        self.assertEqual(obtained_order, reqd_order)


### PR DESCRIPTION
Features in this PR : 
* Rename `_graph_prune` to `graph_prune`
* Add a test case to verify pruning of transformation nodes without user any references
* Remove `_dfs` created earlier as a part of `Node` class