### PR TITLE
Change callable to recursive, Fixes #8

### DIFF
--- a/PyRDF/CallableGenerator.py
+++ b/PyRDF/CallableGenerator.py
@@ -7,11 +7,6 @@ class CallableGenerator(object):
 
     """
     def __init__(self, root_node):
-        
-        self.actions = 0
-        self.tfs = 0
-        self.operations = []
-        self.action_node_map = {}
         self.root_node = root_node
 
     def _dfs(self, node, prev = 't', ops = []):
@@ -66,30 +61,22 @@ class CallableGenerator(object):
 
         self.root_node.graph_prune()
 
-        self.actions = 0
-        self.tfs = 0
-        self.operations = []
-        self.action_node_map = {}
-        self._dfs(self.root_node)
+        def mapper(t, node=None, return_vals=[], return_nodes=[]):
+            ## TODO : Somehow remove references to any Node object 
+            ## for this to work on Spark
 
-        def mapper(t):
-            ops = {'t':t}
-            ret_actions = {}
-            for tp in self.operations:
-                obj = None
-                for i in range(len(tp[2])):
-                    if i==0:
-                        obj = getattr(ops[tp[1]], tp[2][i].name)(*tp[2][i].args, **tp[2][i].kwargs)
-                    else:
-                        obj = getattr(obj, tp[2][i].name)(*tp[2][i].args, **tp[2][i].kwargs)
+            if not node:
+                node = self.root_node
+            else:
+                t = getattr(t, node.operation.name)(*node.operation.args, **node.operation.kwargs)
+                if node.operation.op_type==Operation.Types.ACTION:
+                    return_vals.append(t)
+                    return_nodes.append(node)
 
-                ops[tp[0]] = obj
+            for n in node.next_nodes:
+                mapper(t, n, return_vals)
 
-                if tp[0][:2] == "ta":
-                    ret_actions[tp[0]] = obj
-
-
-            return ret_actions
+            return (return_vals, return_nodes)
 
         return mapper
 

--- a/PyRDF/backend/Local.py
+++ b/PyRDF/backend/Local.py
@@ -12,11 +12,11 @@ def local_executor(generator):
     for f in generator.root_node.filelist:
         filenames_vec.push_back(f)
 
-    TDF = ROOT.ROOT.RDataFrame(generator.root_node.treename, filenames_vec)
+    rdf = ROOT.ROOT.RDataFrame(generator.root_node.treename, filenames_vec)
 
-    output = mapper(TDF)
+    values, nodes = mapper(rdf)
 
-    output[0][0].GetValue() # Trigger event-loop
+    values[0].GetValue() # Trigger event-loop
 
-    for i in range(len(output[0])):
-        output[1][i].value = output[0][i]
+    for i in range(len(values)):
+        nodes[i].value = values[i]

--- a/PyRDF/backend/Local.py
+++ b/PyRDF/backend/Local.py
@@ -16,9 +16,7 @@ def local_executor(generator):
 
     output = mapper(TDF)
 
-    node_map = generator.action_node_map
+    output[0][0].GetValue() # Trigger event-loop
 
-    list(output.values())[0].GetValue() # Trigger event-loop
-
-    for n in node_map:
-        node_map[n].value = output[n]
+    for i in range(len(output[0])):
+        output[1][i].value = output[0][i]

--- a/tests/test_callable_generator.py
+++ b/tests/test_callable_generator.py
@@ -31,12 +31,13 @@ class CallableGeneratorTest(unittest.TestCase):
 
         mp = CallableGenerator(node)
         mapper_func = mp.get_callable()
-        actions = mapper_func(t)
+        output = mapper_func(t)
 
         reqd_order = [1, 3, 2, 2, 3, 2]
 
         self.assertEqual(t.ord_list, reqd_order)
-        self.assertEqual(list(actions.keys()), ['ta1', 'ta2'])
+        self.assertListEqual(output[1], [n5.action_node, n4.action_node])
+        self.assertListEqual(output[0], [t, t])
 
     def test_mapper_with_pruning(self):
         t = CallableGeneratorTest.Temp()
@@ -52,9 +53,10 @@ class CallableGeneratorTest(unittest.TestCase):
 
         mp = CallableGenerator(node)
         mapper_func = mp.get_callable()
-        actions = mapper_func(t)
+        output = mapper_func(t)
 
         reqd_order = [1, 2, 2, 2, 3, 2]
 
         self.assertEqual(t.ord_list, reqd_order)
-        self.assertEqual(list(actions.keys()), ['ta1'])
+        self.assertListEqual(output[1], [n4.action_node])
+        self.assertListEqual(output[0], [t])

--- a/tests/test_callable_generator.py
+++ b/tests/test_callable_generator.py
@@ -31,13 +31,13 @@ class CallableGeneratorTest(unittest.TestCase):
 
         mp = CallableGenerator(node)
         mapper_func = mp.get_callable()
-        output = mapper_func(t)
+        nodes, values = mapper_func(t)
 
         reqd_order = [1, 3, 2, 2, 3, 2]
 
         self.assertEqual(t.ord_list, reqd_order)
-        self.assertListEqual(output[1], [n5.action_node, n4.action_node])
-        self.assertListEqual(output[0], [t, t])
+        self.assertListEqual(values, [n5.action_node, n4.action_node])
+        self.assertListEqual(nodes, [t, t])
 
     def test_mapper_with_pruning(self):
         t = CallableGeneratorTest.Temp()
@@ -53,10 +53,10 @@ class CallableGeneratorTest(unittest.TestCase):
 
         mp = CallableGenerator(node)
         mapper_func = mp.get_callable()
-        output = mapper_func(t)
+        nodes, values = mapper_func(t)
 
         reqd_order = [1, 2, 2, 2, 3, 2]
 
         self.assertEqual(t.ord_list, reqd_order)
-        self.assertListEqual(output[1], [n4.action_node])
-        self.assertListEqual(output[0], [t])
+        self.assertListEqual(values, [n4.action_node])
+        self.assertListEqual(nodes, [t])


### PR DESCRIPTION
Features in this PR : 
* Implement a recursive callable that returns `([TResultPtr1, TResultPtr2, ...], [action_node1, action_node2, .....])`. In short, it returns a tuple of the values list and leaf nodes list
* Update tests for the recursive callable