### PR TITLE
Clean up code

### DIFF
--- a/PyRDF/CallableGenerator.py
+++ b/PyRDF/CallableGenerator.py
@@ -7,63 +7,21 @@ class CallableGenerator(object):
 
     Attributes
     ----------
-    root_node
+    head_node
         Head node of a PyRDF graph.
 
     """
-    def __init__(self, root_node):
+    def __init__(self, head_node):
         """
         Creates a new `CallableGenerator`.
 
         Parameters
         ----------
-        root_node
+        head_node
             Head node of a PyRDF graph.
 
         """
-        self.root_node = root_node
-
-    def _dfs(self, node, prev = 't', ops = []):
-        """
-        Method that does a depth-first
-        traversal and takes note of the 
-        necessary operations to carry out.
-
-        """
-
-        ops_copy = list(ops)
-
-        if not node.operation: # If root
-            for n in node.next_nodes:
-                self._dfs(n)
-            return
-
-        if node.operation.op_type == Operation.Types.ACTION:
-            self.actions+=1
-            
-            ops_copy.append(node.operation)
-            
-            new_var_name = "ta"+str(self.actions)
-            self.operations.append((new_var_name, prev, ops_copy))
-            self.action_node_map[new_var_name] = node
-
-        else:
-            if len(node.next_nodes) != 1:
-                self.tfs+=1
-
-                ops_copy.append(node.operation)
-                
-                cur = 'tt'+ str(self.tfs)
-                self.operations.append((cur, prev, ops_copy))
-                new_tuple = (cur, [])
-            
-            else:
-                ops_copy.append(node.operation)
-                new_tuple = (prev, ops_copy)
-
-            for n in node.next_nodes:
-                self._dfs(n, *new_tuple)
-
+        self.head_node = head_node
 
     def get_callable(self):
         """
@@ -79,7 +37,7 @@ class CallableGenerator(object):
 
         """
 
-        self.root_node.graph_prune()
+        self.head_node.graph_prune()
 
         def mapper(node_cpp, node_py=None):
             """
@@ -111,7 +69,7 @@ class CallableGenerator(object):
             if not node_py:
                 # In the first recursive state, just set the
                 # current PyRDF node as the head node
-                node_py = self.root_node
+                node_py = self.head_node
             else:
                 # Execute the current operation using the output of the parent node (node_cpp)
                 node_cpp = getattr(node_cpp, node_py.operation.name)(*node_py.operation.args, **node_py.operation.kwargs)
@@ -121,7 +79,7 @@ class CallableGenerator(object):
                     return_vals.append(node_cpp)
                     return_nodes.append(node_py)
 
-            for n in node_py.next_nodes:
+            for n in node_py.children:
                 # Recurse through children and get their output
                 prev_vals, prev_nodes = mapper(node_cpp, n)
 

--- a/PyRDF/Node.py
+++ b/PyRDF/Node.py
@@ -15,11 +15,15 @@ class Node(object):
 
     Attributes
     ----------
+    get_head : function
+            A lambda function that returns the head
+            node of the current graph.
+
     operation
         The operation that this Node represents. This
         could be `None`.
 
-    next_nodes
+    children
         A list of `Node` objects which represent the
         children nodes connected to the current node.
 
@@ -31,13 +35,13 @@ class Node(object):
         execution.
 
     """
-    def __init__(self, _get_head, operation):
+    def __init__(self, get_head, operation):
         """
         Creates a new `Node` based on the 'operation'.
 
         Parameters
         ----------
-        _get_head : function
+        get_head : function
             A lambda function that returns the head
             node of the current graph. This value
             could be `None`.
@@ -46,14 +50,14 @@ class Node(object):
             The operation that this Node represents. This
             could be `None`.
         """
-        if _get_head is None:
+        if get_head is None:
             # Function to get 'head' Node
-            self._get_head = lambda : self
+            self.get_head = lambda : self
         else:
-            self._get_head = _get_head
+            self.get_head = get_head
         
         self.operation = operation
-        self.next_nodes = []
+        self.children = []
         self._cur_attr = "" # Name of the new incoming operation
         self.value = None
 
@@ -88,10 +92,10 @@ class Node(object):
         op = Operation(self._cur_attr, *args, **kwargs)
 
         # Create a new `Node` object to house the operation
-        newNode = Node(operation=op, _get_head=self._get_head)
+        newNode = Node(operation=op, get_head=self.get_head)
 
         # Add the new node as a child of the current node
-        self.next_nodes.append(newNode)
+        self.children.append(newNode)
 
         # Return a Proxy object if the new node
         # is an action node
@@ -115,15 +119,15 @@ class Node(object):
 
         children = []
 
-        for n in self.next_nodes:
+        for n in self.children:
             # Select children based on
             # pruning condition
             if n.graph_prune():
                 children.append(n)
 
-        self.next_nodes = children
+        self.children = children
 
-        if not self.next_nodes and len(gc.get_referrers(self)) <= 3:
+        if not self.children and len(gc.get_referrers(self)) <= 3:
             
             ### The 3 referrers to the current node would be :
             ### - The current function (graph_prune())

--- a/PyRDF/Proxy.py
+++ b/PyRDF/Proxy.py
@@ -57,7 +57,7 @@ class Proxy(object):
         # and returns result of the current action node.
 
         if not self.action_node.value: # If event-loop not triggered
-            generator = CallableGenerator(self.action_node._get_head())
+            generator = CallableGenerator(self.action_node.get_head())
             Proxy.backend.execute(generator)
 
         return getattr(self.action_node.value, self._cur_attr)(*args, **kwargs)

--- a/PyRDF/backend/Local.py
+++ b/PyRDF/backend/Local.py
@@ -22,7 +22,7 @@ class Local(Backend):
 
         mapper = generator.get_callable() # Get the callable
 
-        rdf = ROOT.ROOT.RDataFrame(*generator.root_node.args) # Create RDF object
+        rdf = ROOT.ROOT.RDataFrame(*generator.head_node.args) # Create RDF object
 
         values, nodes = mapper(rdf) # Execute the mapper function
 

--- a/tests/test_node.py
+++ b/tests/test_node.py
@@ -124,7 +124,7 @@ class DfsTest(unittest.TestCase):
             op = getattr(prev_object, node.operation.name)
             node.value = op(*node.operation.args, **node.operation.kwargs)
 
-        for n in node.next_nodes:
+        for n in node.children:
             DfsTest.traverse(n, node.value)
 
         return prev_object.ord_list
@@ -151,7 +151,7 @@ class DfsTest(unittest.TestCase):
         # Action pruning
         n5 = n1.Filter() # n5 was an action node earlier
 
-        obtained_order = DfsTest.traverse(node = node._get_head())
+        obtained_order = DfsTest.traverse(node = node.get_head())
 
         reqd_order = [1, 2, 2, 2, 3, 2]
 
@@ -178,7 +178,7 @@ class DfsTest(unittest.TestCase):
         # Transformation pruning
         n5 = n1.Count() # n5 was earlier a transformation node
 
-        obtained_order = DfsTest.traverse(node = node._get_head())
+        obtained_order = DfsTest.traverse(node = node.get_head())
 
         reqd_order = [1, 3, 2, 2, 3, 2]
 
@@ -206,7 +206,7 @@ class DfsTest(unittest.TestCase):
         # Remove references from n4 and it's parent nodes
         n4 = n3 = n2 = None
 
-        obtained_order = DfsTest.traverse(node = node._get_head())
+        obtained_order = DfsTest.traverse(node = node.get_head())
 
         reqd_order = [1, 2, 2]
 
@@ -233,7 +233,7 @@ class DfsTest(unittest.TestCase):
         # Remove references from n2 (which shouldn't affect the graph)
         n2 = None
 
-        obtained_order = DfsTest.traverse(node = node._get_head())
+        obtained_order = DfsTest.traverse(node = node.get_head())
 
         reqd_order = [1, 2, 2, 2, 3, 2]
         # Removing references from n2 will not prune any node
@@ -260,7 +260,7 @@ class DfsTest(unittest.TestCase):
         n5 = n1.Count()
         n6 = node.Filter()
 
-        obtained_order = DfsTest.traverse(node = node._get_head())
+        obtained_order = DfsTest.traverse(node = node.get_head())
 
         reqd_order = [1, 3, 2, 2, 3, 2]
 


### PR DESCRIPTION
Features in this PR : 
* Remove the unwanted `_dfs` function from `CallableGenerator` class
* Variable name changes
    - Change `root_node` -> `head_node` in `CallableGenerator` class and refactor
    - Change `_get_head` -> `get_head` in `Node` class and refactor
    - Change `next_nodes` -> `children` in `Node` class and refactor
