### PR TITLE
Remove unwanted import in CallableGenerator

### DIFF
--- a/PyRDF/CallableGenerator.py
+++ b/PyRDF/CallableGenerator.py
@@ -1,5 +1,3 @@
-from .Operation import Operation
-
 class CallableGenerator(object):
     """
     Class that generates a callable


### PR DESCRIPTION
Features in this PR : 
* Remove an unwanted `Operation` import in `CallableGenerator` (should've been removed along with the `is_action` implementation PR