### PR TITLE
Change Backend implementation to check supported operations

### DIFF
--- a/PyRDF/Node.py
+++ b/PyRDF/Node.py
@@ -87,6 +87,11 @@ class Node(object):
         # Handles an operation call to the current node and
         # returns the new node built using the operation call.
 
+        from . import current_backend
+        # Check if the current operation is supported by
+        # the backend
+        current_backend.check_supported(self._cur_attr)
+
         # Create a new `Operation` object for the
         # incoming operation call
         op = Operation(self._cur_attr, *args, **kwargs)

--- a/PyRDF/Operation.py
+++ b/PyRDF/Operation.py
@@ -89,16 +89,6 @@ class Operation(object):
         # Classifies the given operation as action or
         # transformation and returns the type.
 
-        future_ops = [
-        "Range",
-        "Take",
-        "Snapshot",
-        "Foreach"
-        ]
-
-        if name in future_ops:
-            raise NotImplementedError("This operation ({}) isn't supported yet ! ".format(name))
-
         ops = Operation.Types
 
         operations_dict = {

--- a/PyRDF/Proxy.py
+++ b/PyRDF/Proxy.py
@@ -20,8 +20,6 @@ class Proxy(object):
         instance wraps.
 
     """
-    backend = None
-
     def __init__(self, action_node):
         """
         Creates a new `Proxy` object for a
@@ -57,7 +55,8 @@ class Proxy(object):
         # and returns result of the current action node.
 
         if not self.action_node.value: # If event-loop not triggered
+            from . import current_backend
             generator = CallableGenerator(self.action_node.get_head())
-            Proxy.backend.execute(generator)
+            current_backend.execute(generator)
 
         return getattr(self.action_node.value, self._cur_attr)(*args, **kwargs)

--- a/PyRDF/__init__.py
+++ b/PyRDF/__init__.py
@@ -5,19 +5,21 @@ from .Operation import Operation
 from .CallableGenerator import CallableGenerator
 from .backend import Local, Dist
 
-Proxy.backend = Local()
+current_backend = Local()
 
-def use(backend, conf = {}):
+def use(backend_name, conf = {}):
 
     future_backends = [
     "dask"
     ]
 
-    if backend in future_backends:
+    global current_backend
+
+    if backend_name in future_backends:
         raise NotImplementedError(" This backend environment will be considered in the future !")
-    elif backend == "local":
-        Proxy.backend = Local(conf)
-    elif backend == "spark":
-        Proxy.backend = Dist(conf)
+    elif backend_name == "local":
+        current_backend = Local(conf)
+    elif backend_name == "spark":
+        current_backend = Dist(conf)
     else:
         raise Exception(" Incorrect backend environment \"{}\"".format(backend))

--- a/PyRDF/backend/Backend.py
+++ b/PyRDF/backend/Backend.py
@@ -14,6 +14,29 @@ class Backend(ABC):
         backend.
 
     """
+    supported_operations = [
+        'Define',
+        'Filter',
+        'Histo1D',
+        'Histo2D',
+        'Histo3D',
+        'Profile1D',
+        'Profile2D',
+        'Profile3D',
+        'Count',
+        'Min',
+        'Max',
+        'Mean',
+        'Sum',
+        'Fill',
+        'Report',
+        'Range',
+        'Take',
+        'Snapshot',
+        'Foreach',
+        'Reduce',
+        'Aggregate'
+        ]
 
     def __init__(self, config={}):
         """
@@ -29,6 +52,25 @@ class Backend(ABC):
 
         """
         self.config = config
+
+    def check_supported(self, operation_name):
+        """
+        Checks if a given operation is supported
+        in the given backend.
+
+        Parameters
+        ----------
+        operation_name
+            Name of the operation to be checked.
+
+        Returns
+        -------
+        Operation.Types
+            The type of the current operation.
+
+        """
+        if operation_name not in self.supported_operations:
+            raise Exception("Invalid operation \"{}\"".format(operation_name))
 
     @abstractmethod
     def execute(self, generator):

--- a/PyRDF/backend/Local.py
+++ b/PyRDF/backend/Local.py
@@ -13,6 +13,33 @@ class Local(Backend):
         backend.
 
     """
+    def __init__(self, config={}):
+        """
+        Creates a new instance of the
+        Local implementation of `Backend`.
+
+        Parameters
+        ----------
+        config (optional)
+            The config object for the required
+            backend. The default value is an
+            empty Python dictionary `{}`.
+
+        """
+        super().__init__(config)
+        operations_not_supported = [
+        'Take',
+        'Snapshot',
+        'Foreach',
+        'Reduce',
+        'Aggregate'
+        ]
+        if ROOT.ROOT.IsImplicitMTEnabled():
+            # Add `Range` operation only if multi-threading
+            # is disabled.
+            operations_not_supported.append('Range')
+
+        self.supported_operations = [op for op in self.supported_operations if op not in operations_not_supported]
 
     def execute(self, generator):
         """

--- a/tests/test_backend.py
+++ b/tests/test_backend.py
@@ -1,6 +1,5 @@
-import PyRDF
+import PyRDF, unittest, ROOT
 from PyRDF import Proxy, Local, Dist
-import unittest
 
 class SelectionTest(unittest.TestCase):
     """
@@ -17,7 +16,7 @@ class SelectionTest(unittest.TestCase):
         """
 
         PyRDF.use("local")
-        self.assertIsInstance(Proxy.backend, Local)
+        self.assertIsInstance(PyRDF.current_backend, Local)
 
     def test_dist_select(self):
         """
@@ -27,7 +26,7 @@ class SelectionTest(unittest.TestCase):
         """
 
         PyRDF.use("spark")
-        self.assertIsInstance(Proxy.backend, Dist)
+        self.assertIsInstance(PyRDF.current_backend, Dist)
 
     def test_future_env_select(self):
         """
@@ -67,3 +66,83 @@ class BackendInitTest(unittest.TestCase):
 
         with self.assertRaises(TypeError):
             TestBackend()
+
+class OperationSupportTest(unittest.TestCase):
+    """
+    Test cases to ensure that incoming operations are
+    classified accurately in local environment.
+
+    """
+
+    def test_action(self):
+        """
+        Test case to check that action nodes
+        are classified accurately.
+
+        """
+
+        backend = Local()
+        op = backend.check_supported("Count")
+
+    def test_transformation(self):
+        """
+        Test case to check that transformation
+        nodes are classified accurately.
+
+        """
+
+        backend = Local()
+        op = backend.check_supported("Define")
+
+    def test_locally_unsupported_operations(self):
+        """
+        Test case to check that unsupported operations
+        raise an Exception.
+
+        """
+
+        backend = Local()
+        with self.assertRaises(Exception):
+            op = backend.check_supported("Take")
+
+        with self.assertRaises(Exception):
+            op = backend.check_supported("Snapshot")
+
+        with self.assertRaises(Exception):
+            op = backend.check_supported("Foreach")
+
+    def test_none(self):
+        """
+        Test case to check that incorrect operations
+        raise an Exception.
+
+        """
+
+        backend = Local()
+        with self.assertRaises(Exception):
+            op = backend.check_supported("random")
+
+    def test_range_operation_single_thread(self):
+        """
+        Test case to check that 'Range' operation
+        works in single-threaded mode and raises an
+        Exception in multi-threaded mode.
+
+        """
+
+        backend = Local()
+        backend.check_supported("Range")
+
+    def test_range_operation_multi_thread(self):
+        """
+        Test case to check that 'Range' operation
+        raises an Exception in multi-threaded mode.
+
+        """
+
+        ROOT.ROOT.EnableImplicitMT()
+        backend = Local()
+        with self.assertRaises(Exception):
+            op = backend.check_supported("Range")
+
+        ROOT.ROOT.DisableImplicitMT()


### PR DESCRIPTION
Features in this PR : 
* Add `is_supported` function in `Backend` class to check if an operation is supported
* Add a `supported_operations` and `future_operations` dictionary to `Backend` class
* Remove `Proxy.backend` and create a global named `current_backend` inside `__init__.py` so that all modules inside `PyRDF` can access them (in this case `Proxy` and `Operation`, but may be more in the future)
* Add/Modify tests for the above features