### PR TITLE
Add more operations to operations_dict

### DIFF
--- a/PyRDF/Operation.py
+++ b/PyRDF/Operation.py
@@ -59,7 +59,7 @@ class Operation(object):
 
     """
 
-    Types = Enum("Types", "ACTION TRANSFORMATION")
+    Types = Enum("Types", "ACTION TRANSFORMATION INSTANT_ACTION")
 
     def __init__(self, name, *args, **kwargs):
         """
@@ -94,6 +94,8 @@ class Operation(object):
         operations_dict = {
         'Define':ops.TRANSFORMATION,
         'Filter':ops.TRANSFORMATION,
+        'Range':ops.TRANSFORMATION,
+        'Aggregate':ops.ACTION,
         'Histo1D':ops.ACTION,
         'Histo2D':ops.ACTION,
         'Histo3D':ops.ACTION,
@@ -106,9 +108,13 @@ class Operation(object):
         'Mean':ops.ACTION,
         'Sum':ops.ACTION,
         'Fill':ops.ACTION,
-        'Report':ops.ACTION
+        'Reduce':ops.ACTION,
+        'Report':ops.ACTION,
+        'Take':ops.ACTION,
+        'Snapshot':ops.INSTANT_ACTION,
+        'Foreach':ops.INSTANT_ACTION
         }
-        
+
         op_type = operations_dict.get(name)
 
         if not op_type:

--- a/PyRDF/backend/Backend.py
+++ b/PyRDF/backend/Backend.py
@@ -70,7 +70,7 @@ class Backend(ABC):
 
         """
         if operation_name not in self.supported_operations:
-            raise Exception("Invalid operation \"{}\"".format(operation_name))
+            raise Exception("The current backend doesn't support \"{}\" !".format(operation_name))
 
     @abstractmethod
     def execute(self, generator):

--- a/tests/test_operation.py
+++ b/tests/test_operation.py
@@ -18,6 +18,15 @@ class ClassifyTest(unittest.TestCase):
         op = Operation("Count")
         self.assertEqual(op.op_type, Operation.Types.ACTION)
 
+    def test_instant_action(self):
+        """
+        Test case to check that instant
+        actions are classified accurately.
+
+        """
+        op = Operation("Snapshot")
+        self.assertEqual(op.op_type, Operation.Types.INSTANT_ACTION)
+
     def test_transformation(self):
         """
         Test case to check that transformation


### PR DESCRIPTION
Features in this PR : 
* Add more operations to `operations_dict`
* Add one more operation type (`INSTANT_ACTION`) correctly classify operations like `Snapshot` and `Foreach`
* Add a unit test to check classification of instant actions