### PR TITLE
Fix Python 2 issue in Local

### DIFF
--- a/PyRDF/backend/Local.py
+++ b/PyRDF/backend/Local.py
@@ -26,7 +26,7 @@ class Local(Backend):
             empty Python dictionary `{}`.
 
         """
-        super().__init__(config)
+        super(Local, self).__init__(config)
         operations_not_supported = [
         'Take',
         'Snapshot',


### PR DESCRIPTION
Features in this PR : 
* Python 2 doesn't support `super().__init__()`. That is now changed to `super(Local, self).__init__(config)` in Local