### PR TITLE
Make 'Node' objects serializable

### DIFF
--- a/PyRDF/Node.py
+++ b/PyRDF/Node.py
@@ -61,6 +61,38 @@ class Node(object):
         self._cur_attr = "" # Name of the new incoming operation
         self.value = None
 
+    def __getstate__(self):
+        """
+        Converts the state of the current node
+        to a Python dictionary.
+
+        Returns
+        -------
+        Python Dictionary
+            A dictionary that stores all instance variables
+            that represent the current PyRDF node.
+
+        """
+        state_dict = {'children':self.children}
+        if self.operation:
+            state_dict['operation_name'] = self.operation.name
+            state_dict['operation_args'] = self.operation.args
+            state_dict['operation_kwargs'] = self.operation.kwargs
+
+        return state_dict
+
+    def __setstate__(self, state):
+        """
+        Retrieves the state dictionary of the current
+        node and sets the instance variables.
+
+        """
+        self.children = state['children']
+        if state.get('operation_name'):
+            self.operation = Operation(state['operation_name'], *state['operation_args'], **state["operation_kwargs"])
+        else:
+            self.operation = None
+
     def __getattr__(self, attr):
         """
         Intercepts any call to the current node and dispatches
@@ -81,6 +113,13 @@ class Node(object):
         """
 
         self._cur_attr = attr # Stores new operation name
+
+        # Check if the current call is a dunder method call
+        import re
+        if re.search("^__[a-z]+__$", attr):
+            # Raise an AttributeError for all dunder method calls
+            raise AttributeError("Such an attribute is not set ! ")
+
         return self._call_handler
 
     def _call_handler(self, *args, **kwargs):

--- a/tests/test_node.py
+++ b/tests/test_node.py
@@ -265,3 +265,141 @@ class DfsTest(unittest.TestCase):
         reqd_order = [1, 3, 2, 2, 3, 2]
 
         self.assertEqual(obtained_order, reqd_order)
+
+class DunderMethodsTest(unittest.TestCase):
+    """
+    Test cases to check the response of
+    the Node class for various dunder
+    method calls.
+
+    """
+    def test_get_state(self):
+        """
+        Test cases to check the working of
+        __getstate__ method on Node class.
+
+        """
+        node = Node(None, None) # Head node
+        n1 = node.Define("a", b="c") # First child node
+
+        # Required dictionaries
+        node_dict = {"children":[n1]}
+        n1_dict = {
+        'operation_name':"Define",
+        'operation_args':("a",),
+        'operation_kwargs':{"b":"c"},
+        'children':[]
+        }
+
+        self.assertDictEqual(node.__getstate__(), node_dict)
+        self.assertDictEqual(n1.__getstate__(), n1_dict)
+
+    def test_set_state(self):
+        """
+        Test cases to check the working of
+        __setstate__ method on Node class.
+
+        """
+        node = Node(None, None) # Head node
+        n1 = Node(None, None) # First child node
+
+        # State dictionaries
+        node_dict = {"children":[n1]}
+        n1_dict = {
+        'operation_name':"Define",
+        'operation_args':("a",),
+        'operation_kwargs':{"b":"c"},
+        'children':[]
+        }
+
+        # Set node objects with state dicts
+        node.__setstate__(node_dict)
+        n1.__setstate__(n1_dict)
+
+        self.assertListEqual([node.operation, node.children], [None, node_dict["children"]])
+        self.assertListEqual([
+            n1.operation.name,
+            n1.operation.args,
+            n1.operation.kwargs,
+            n1.children
+            ], [
+            n1_dict["operation_name"],
+            n1_dict["operation_args"],
+            n1_dict["operation_kwargs"],
+            n1_dict["children"]
+            ])
+
+    def test_other_dunder_methods(self):
+        """
+        Test cases to check the working of
+        other dunder methods on Node class.
+
+        """
+        node = Node(None, None)
+
+        # Regular dunder method must not throw an error
+        node.__format__('')
+
+        with self.assertRaises(AttributeError):
+            node.__random__() # Unknown dunder method
+
+class PickleTest(unittest.TestCase):
+    """
+    Tests to check the pickling an un-pickling of
+    Node instances.
+
+    """
+    def assertGraphs(self, current_node1, current_node2):
+        """
+        Asserts every node in the given graphs starting
+        from the given head nodes.
+
+        """
+        self.assertNodes(current_node1, current_node2) # Equality between nodes
+
+        for n1, n2 in zip(current_node1.children, current_node2.children):
+            self.assertGraphs(n1, n2) # Check the rest of the graphs
+
+    def assertNodes(self, node1, node2):
+        """
+        Assert equality between two given nodes by checking
+        the operation and number of children nodes.
+
+        """
+        self.assertEqual(len(node1.children), len(node2.children)) # Check the number of children
+
+        # Assert operations
+        if not node1.operation:
+            self.assertIsNone(node2.operation)
+        else:
+            self.assertEqual(node1.operation.name, node2.operation.name)
+            self.assertEqual(node1.operation.args, node2.operation.args)
+            self.assertEqual(node1.operation.kwargs, node2.operation.kwargs)
+
+    def test_node_pickle(self):
+        """
+        Test cases to check that nodes can be accurately
+        pickled and un-pickled.
+
+        """
+        import pickle
+
+        # Node definitions
+        node = Node(None, None) # Head node
+        n1 = node.Define("a", b="c") # First child node
+        n2 = n1.Count()
+        n3 = node.Filter("b")
+        n4 = n3.Count()
+
+        # Pickled representation of nodes
+        pickled_node = pickle.dumps(node)
+        pickled_n3 = pickle.dumps(n3)
+
+        # Un-pickled node objects
+        unpickled_node = pickle.loads(pickled_node)
+        unpickled_n3 = pickle.loads(pickled_n3)
+
+        self.assertIsInstance(unpickled_node, type(node))
+        self.assertIsInstance(unpickled_n3, type(n3))
+        self.assertGraphs(node, unpickled_node)
+        self.assertGraphs(n3, unpickled_n3)


### PR DESCRIPTION
Features in this PR : 
* Make objects of `Node` class serializable (picklable) by implementing `__getstate__` and `__setstate__` dunder methods
* Add unit tests to check `Node` serializability