### PR TITLE
Remove imports of Node, Proxy and Operation

### DIFF
--- a/PyRDF/__init__.py
+++ b/PyRDF/__init__.py
@@ -1,7 +1,4 @@
 from .RDataFrame import RDataFrame, RDataFrameException
-from .Node import Node
-from .Proxy import Proxy
-from .Operation import Operation
 from .CallableGenerator import CallableGenerator
 from .backend import Local, Spark
 

--- a/tests/unit/test_callable_generator.py
+++ b/tests/unit/test_callable_generator.py
@@ -1,4 +1,5 @@
-from PyRDF import *
+from PyRDF import CallableGenerator
+from PyRDF.Node import Node
 import unittest
 
 class CallableGeneratorTest(unittest.TestCase):

--- a/tests/unit/test_node.py
+++ b/tests/unit/test_node.py
@@ -1,4 +1,5 @@
-from PyRDF import *
+from PyRDF.Node import Node
+from PyRDF.Proxy import Proxy
 import unittest
 
 class OperationReadTest(unittest.TestCase):

--- a/tests/unit/test_operation.py
+++ b/tests/unit/test_operation.py
@@ -1,4 +1,4 @@
-from PyRDF import *
+from PyRDF.Operation import Operation
 import unittest
 
 class ClassifyTest(unittest.TestCase):

--- a/tests/unit/test_proxy.py
+++ b/tests/unit/test_proxy.py
@@ -1,4 +1,5 @@
-from PyRDF import *
+from PyRDF.Proxy import Proxy
+from PyRDF.Node import Node
 import unittest
 
 class AttrReadTest(unittest.TestCase):


### PR DESCRIPTION
Features in this PR : 
* Remove imports of Node, Proxy and Operation classes from PyRDF's `__init__.py`
* Fix the imports in required tests