### PR TITLE
Remove the logic for processing integers in reducer and add Spark tutorials

### DIFF
--- a/.travis-script.sh
+++ b/.travis-script.sh
@@ -56,3 +56,16 @@ do
 done
 
 echo " ======== Ran multi-threaded tutorials successfully ! ======== "
+
+echo "======== Running Spark tutorials ======== "
+
+
+# Run Spark tutorials locally
+for filename in ./tutorials/spark/df*.py
+do
+	echo " == Running $filename == "
+	python "$filename" || exit 1
+	echo "  Ran $filename successfully ! "
+done
+
+echo " ======== Ran Spark tutorials successfully ! ======== "

--- a/PyRDF/Operation.py
+++ b/PyRDF/Operation.py
@@ -111,6 +111,7 @@ class Operation(object):
         'Reduce':ops.ACTION,
         'Report':ops.ACTION,
         'Take':ops.ACTION,
+        'Graph':ops.ACTION,
         'Snapshot':ops.INSTANT_ACTION,
         'Foreach':ops.INSTANT_ACTION
         }

--- a/PyRDF/backend/Backend.py
+++ b/PyRDF/backend/Backend.py
@@ -35,7 +35,8 @@ class Backend(ABC):
         'Snapshot',
         'Foreach',
         'Reduce',
-        'Aggregate'
+        'Aggregate',
+        'Graph'
         ]
 
     def __init__(self, config={}):

--- a/run_tests.sh
+++ b/run_tests.sh
@@ -104,3 +104,22 @@ done
 }
 
 echo "\n======== \033[0;32m Ran multi-threaded tutorials successfully ! \033[0m ========\n"
+
+echo "======== Running Spark tutorials ========\n"
+
+{
+
+# Run Spark tutorials locally
+for filename in ./tutorials/spark/df*.py
+do
+	echo "\n== Running $filename ==\n"
+	$python_bin "$filename"
+	echo "\n \033[0;32m Ran $filename successfully ! \033[0m"
+done
+
+} || {
+	echo "Error in running tutorials ! Check if you're in the PyRDF root directory !"
+	exit 1
+}
+
+echo "\n======== \033[0;32m Ran Spark tutorials successfully ! \033[0m ========\n"

--- a/tests/integration/spark/test_reducer_merge.py
+++ b/tests/integration/spark/test_reducer_merge.py
@@ -1,0 +1,168 @@
+import unittest, PyRDF, ROOT
+
+class ReducerMergeTest(unittest.TestCase):
+    """
+    Integration tests to check the working of merge operations
+    in the reducer function.
+
+    """
+    @classmethod
+    def setUpClass(cls):
+        """
+        Set up method to select Spark backend
+        before running all the tests.
+
+        """
+        PyRDF.use("spark", {'npartitions':2, 'spark.executor.instances':2})
+
+    def assertHistoOrProfile(self, obj_1, obj_2):
+        """
+        Asserts equality between two 'ROOT.TH1' or
+        'ROOT.TH2' objects.
+
+        """
+        # Compare the sizes of equivalent objects
+        self.assertEqual(obj_1.GetEntries(), obj_2.GetEntries())
+
+        # Compare the means of equivalent objects
+        self.assertEqual(obj_1.GetMean(), obj_2.GetMean())
+
+        # Compare the standard deviations of equivalent objects
+        self.assertEqual(obj_1.GetStdDev(), obj_2.GetStdDev())
+
+    def define_two_columns(self, rdf):
+        """
+        Helper method that Defines and returns
+        two columns with definitions "x = tdfentry_"
+        and "y = tdfentry_ * tdfentry_".
+
+        """
+        return rdf.Define("x", "tdfentry_").Define("y", "tdfentry_*tdfentry_")
+
+    def define_three_columns(self, rdf):
+        """
+        Helper method that Defines and returns three columns
+        with definitions "x = tdfentry_", "y = tdfentry_ * tdfentry_"
+        and "z = tdfentry_ * tdfentry_ * tdfentry_".
+
+        """
+        return rdf.Define("x", "tdfentry_").Define("y", "tdfentry_*tdfentry_").Define("z", "tdfentry_*tdfentry_*tdfentry_")
+
+    def test_histo1d_merge(self):
+        """
+        Integration test to check the working of
+        Histo1D merge operation in the reducer.
+
+        """
+        # Operations with PyRDF
+        rdf_py = PyRDF.RDataFrame(10)
+        histo_py = rdf_py.Histo1D("tdfentry_")
+
+        # Operations with PyROOT
+        rdf_cpp = ROOT.ROOT.RDataFrame(10)
+        histo_cpp = rdf_cpp.Histo1D("tdfentry_")
+
+        # Compare the 2 histograms
+        self.assertHistoOrProfile(histo_py, histo_cpp)
+
+    def test_histo2d_merge(self):
+        """
+        Integration test to check the working of
+        Histo2D merge operation in the reducer.
+
+        """
+        # Operations with PyRDF
+        rdf_py = PyRDF.RDataFrame(10)
+        columns_py = self.define_two_columns(rdf_py)
+        histo_py = columns_py.Histo2D(("", "", 64, -4, 4, 64, -4, 4), "x", "y")
+
+        # Operations with PyROOT
+        rdf_cpp = ROOT.ROOT.RDataFrame(10)
+        columns_cpp = self.define_two_columns(rdf_cpp)
+        histo_cpp = columns_cpp.Histo2D(("", "", 64, -4, 4, 64, -4, 4), "x", "y")
+
+        # Compare the 2 histograms
+        self.assertHistoOrProfile(histo_py, histo_cpp)
+
+    def test_histo3d_merge(self):
+        """
+        Integration test to check the working of
+        Histo3D merge operation in the reducer.
+
+        """
+        # Operations with PyRDF
+        rdf_py = PyRDF.RDataFrame(10)
+        columns_py = self.define_three_columns(rdf_py)
+        histo_py = columns_py.Histo3D(("", "", 64, -4, 4, 64, -4, 4, 64, -4, 4), "x", "y", "z")
+
+        # Operations with PyROOT
+        rdf_cpp = ROOT.ROOT.RDataFrame(10)
+        columns_cpp = self.define_three_columns(rdf_cpp)
+        histo_cpp = columns_cpp.Histo3D(("", "", 64, -4, 4, 64, -4, 4, 64, -4, 4), "x", "y", "z")
+
+        # Compare the 2 histograms
+        self.assertHistoOrProfile(histo_py, histo_cpp)
+
+    def test_profile1d_merge(self):
+        """
+        Integration test to check the working of
+        Profile1D merge operation in the reducer.
+
+        """
+        # Operations with PyRDF
+        rdf_py = PyRDF.RDataFrame(10)
+        columns_py = self.define_two_columns(rdf_py)
+        profile_py = columns_py.Profile1D(("", "", 64, -4, 4), "x", "y")
+
+        # Operations with PyROOT
+        rdf_cpp = ROOT.ROOT.RDataFrame(10)
+        columns_cpp = self.define_two_columns(rdf_cpp)
+        profile_cpp = columns_cpp.Profile1D(("", "", 64, -4, 4), "x", "y")
+
+        # Compare the 2 profiles
+        self.assertHistoOrProfile(profile_py, profile_cpp)
+
+    def test_profile2d_merge(self):
+        """
+        Integration test to check the working of
+        Profile2D merge operation in the reducer.
+
+        """
+        # Operations with PyRDF
+        rdf_py = PyRDF.RDataFrame(10)
+        columns_py = self.define_three_columns(rdf_py)
+        profile_py = columns_py.Profile2D(("", "", 64, -4, 4, 64, -4, 4), "x", "y", "z")
+
+        # Operations with PyROOT
+        rdf_cpp = ROOT.ROOT.RDataFrame(10)
+        columns_cpp = self.define_three_columns(rdf_cpp)
+        profile_cpp = columns_cpp.Profile2D(("", "", 64, -4, 4, 64, -4, 4), "x", "y", "z")
+
+        # Compare the 2 profiles
+        self.assertHistoOrProfile(profile_py, profile_cpp)
+
+    def test_tgraph_merge(self):
+        """
+        Integration test to check the working of
+        TGraph merge operation in the reducer.
+
+        """
+        # Operations with PyRDF
+        rdf_py = PyRDF.RDataFrame(10)
+        columns_py = self.define_two_columns(rdf_py)
+        graph_py = columns_py.Graph("x", "y")
+
+        # Operations with PyROOT
+        rdf_cpp = ROOT.ROOT.RDataFrame(10)
+        columns_cpp = self.define_two_columns(rdf_cpp)
+        graph_cpp = columns_cpp.Graph("x", "y")
+
+        # Sort the graphs to make sure corresponding points are same
+        graph_py.Sort()
+        graph_cpp.Sort()
+
+        # Compare the X co-ordinates of the graphs
+        self.assertListEqual(list(graph_py.GetX()), list(graph_cpp.GetX()))
+
+        # Compare the Y co-ordinates of the graphs
+        self.assertListEqual(list(graph_py.GetY()), list(graph_cpp.GetY()))

--- a/tests/unit/backend/test_spark.py
+++ b/tests/unit/backend/test_spark.py
@@ -145,7 +145,7 @@ class OperationSupportTest(unittest.TestCase):
         """
         # Check in Spark env
         backend = Spark()
-        op = backend.check_supported("Count")
+        op = backend.check_supported("Histo1D")
 
     def test_transformation(self):
         """

--- a/tutorials/spark/df003_profiles.py
+++ b/tutorials/spark/df003_profiles.py
@@ -1,0 +1,59 @@
+## \file
+## \ingroup tutorial_dataframe
+## \notebook -nodraw
+## This tutorial illustrates how to use TProfiles in combination with the
+## RDataFrame. See the documentation of TProfile and TProfile2D to better
+## understand the analogy of this code with the example one.
+##
+## \macro_code
+##
+## \date February 2017
+## \author Danilo Piparo
+
+import ROOT, PyRDF
+
+# The second parameter in 'PyRDF.use' call, is the config
+# dictionary. 'npartitions' represents the number of parts
+# that the input dataset should be divided into for processing.
+# 'spark.executor.instances' is a Spark configuration parameter and
+# it represents the number of spark executors that should be used to
+# process the partitioned dataset. Learn more about Spark configuration
+# options from it's official documentation page.
+PyRDF.use("spark", {'npartitions':4, 'spark.executor.instances':4})
+
+RDataFrame = PyRDF.RDataFrame
+
+# A simple helper function to fill a test tree: this makes the example
+# stand-alone.
+def fill_tree(treeName, fileName):
+    d = ROOT.ROOT.RDataFrame(25000)
+    d.Define("px", "gRandom->Gaus()")\
+     .Define("py", "gRandom->Gaus()")\
+     .Define("pz", "sqrt(px * px + py * py)")\
+     .Snapshot(treeName, fileName)
+
+
+
+# We prepare an input tree to run on
+fileName = "df003_profiles.root"
+treeName = "myTree"
+fill_tree(treeName, fileName)
+
+# We read the tree from the file and create a RDataFrame.
+columns = ROOT.vector('string')()
+columns.push_back("px")
+columns.push_back("py")
+columns.push_back("pz")
+d = RDataFrame(treeName, fileName, columns)
+
+# Create the profiles
+hprof1d = d.Profile1D(("hprof1d", "Profile of pz versus px", 64, -4, 4))
+hprof2d = d.Profile2D(("hprof2d", "Profile of pz versus px and py", 40, -4, 4, 40, -4, 4, 0, 20))
+
+# And Draw
+c1 = ROOT.TCanvas("c1", "Profile histogram example", 200, 10, 700, 500)
+hprof1d.Draw()
+c2 = ROOT.TCanvas("c2", "Profile2D histogram example", 200, 10, 700, 500)
+c2.cd()
+hprof2d.Draw()
+

--- a/tutorials/spark/df016_vecOps.py
+++ b/tutorials/spark/df016_vecOps.py
@@ -1,0 +1,39 @@
+## \file
+## \ingroup tutorial_dataframe
+## \notebook -draw
+## This tutorial shows the potential of the VecOps approach for treating collections
+## stored in datasets, a situation very common in HEP data analysis.
+##
+## \macro_code
+##
+## \date February 2018
+## \author Danilo Piparo
+
+import ROOT, PyRDF
+
+PyRDF.use("spark")
+tdf = PyRDF.RDataFrame(1024)
+coordDefineCode = '''ROOT::VecOps::RVec<double> {0}(len);
+                     std::transform({0}.begin(), {0}.end(), {0}.begin(), [](double){{return gRandom->Uniform(-1.0, 1.0);}});
+                     return {0};'''
+d = tdf.Define("len", "gRandom->Uniform(0, 16)")\
+       .Define("x", coordDefineCode.format("x"))\
+       .Define("y", coordDefineCode.format("y"))
+
+# Now we have in hands d, a RDataFrame with two columns, x and y, which
+# hold collections of coordinates. The size of these collections vary.
+# Let's now define radii out of x and y. We'll do it treating the collections
+# stored in the columns without looping on the individual elements.
+d1 = d.Define("r", "sqrt(x*x + y*y)")
+
+# Now we want to plot 2 quarters of a ring with radii .5 and 1
+# Note how the cuts are performed on RVecs, comparing them with integers and
+# among themselves
+ring_h = d1.Define("rInFig", "r > .4 && r < .8 && x*y < 0")\
+           .Define("yFig", "y[rInFig]")\
+           .Define("xFig", "x[rInFig]")\
+           .Histo2D(("fig", "Two quarters of a ring", 64, -1, 1, 64, -1, 1), "xFig", "yFig")
+
+cring = ROOT.TCanvas()
+ring_h.Draw("Colz")
+cring.Print("df016_vecOps_py.png")

--- a/tutorials/spark/df017_vecOpsHEP.py
+++ b/tutorials/spark/df017_vecOpsHEP.py
@@ -1,0 +1,41 @@
+## \file
+## \ingroup tutorial_dataframe
+## \notebook -draw
+## This tutorial shows how VecOps can be used to slim down the programming
+## model typically adopted in HEP for analysis.
+## \macro_code
+##
+## \date March 2018
+## \author Danilo Piparo, Andre Vieira Silva
+
+import ROOT, PyRDF
+from math import sqrt
+
+filename = ROOT.gROOT.GetTutorialDir().Data() + "/dataframe/df017_vecOpsHEP.root"
+treename = "myDataset"
+PyRDF.use("spark")
+RDF = PyRDF.RDataFrame
+
+def WithPyROOT():
+    f = ROOT.TFile(filename)
+    h = ROOT.TH1F("pt", "pt", 16, 0, 4)
+    for event in f.myDataset:
+        for E, px, py in zip(event.E, event.px, event.py):
+            if (E > 100):
+               h.Fill(sqrt(px*px + py*py))
+    h.DrawCopy()
+
+def WithRDataFrameVecOpsJit():
+    f = RDF(treename, filename)
+    h = f.Define("good_pt", "sqrt(px*px + py*py)[E>100]")\
+         .Histo1D(("pt", "pt", 16, 0, 4), "good_pt")
+    h.DrawCopy()
+
+## We plot twice the same quantity, the key is to look into the implementation
+## of the functions above
+c = ROOT.TCanvas()
+c.Divide(2,1)
+c.cd(1)
+WithPyROOT()
+c.cd(2)
+WithRDataFrameVecOpsJit()


### PR DESCRIPTION
In this PR : 
* Remove support for operations on integers like "Sum", "Mean", "Max"....etc. to wait for the generic reducer
* Add tutorials for Spark
* Modify `.travis-script.sh` and `run_tests.sh` to run Spark tutorials as well 